### PR TITLE
Cache toggle states

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fflag (0.1.0)
+    fflag (0.1.1)
       rails (~> 5.1.6, >= 5.1.6.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ end
 ```
 The primary page is `/toggles`, so after mounting the above you would find the page at `localhost:3000/dev/toggles`. By default you the basic password is `FEATUREFLAGBASIC`, however you can change this by setting the `FFLAG_PASSWORD` environment variable.
 
+Optionally you can add an initializer for the gem to customize configurations:
+
+```ruby
+# config/initializers/fflag.rb
+Fflag.configure do |config|
+  config.cache_enable = true # default: false
+end
+```
 ## Usage
 
 Use the `FeatureFlag` class to detect if a toggle is switched on or not. Use the `identifier`  that you specified in the flag_definitions file to reference.

--- a/app/controllers/toggle_controller.rb
+++ b/app/controllers/toggle_controller.rb
@@ -20,5 +20,7 @@ class ToggleController < ActionController::Base
     else
       state.update(activated: params[:toggle_on])
     end
+
+    ::Fflag::CacheManager.clear(params[:identifier])
   end
 end

--- a/app/src/feature_flag.rb
+++ b/app/src/feature_flag.rb
@@ -1,21 +1,20 @@
 class FeatureFlag
-  def self.is_on? (identifier)
-    check_exist identifier
-    state = FeatureFlagState.find_by(identifier: identifier)
-    return false unless state.present?
-    state.activated
+  def self.is_on?(identifier, expires_in: nil)
+    ::Fflag::CacheManager.fetch(identifier, expires_in) do
+      check_exist(identifier)
+      state = FeatureFlagState.find_by(identifier: identifier)
+      state.present? ? state.activated : false
+    end
   end
 
-  def self.is_off? (identifier)
-    check_exist identifier
-    state = FeatureFlagState.find_by(identifier: identifier)
-    return true unless state.present?
-    !state.activated
+  def self.is_off?(identifier, expires_in: nil)
+    !is_on?(identifier, expires_in: expires_in)
   end
 
   def self.check_exist(identifier)
     @index ||= YAML.load_file(FeatureFlagConstants::FEATURE_FLAG_DEFINITION_PATH)
     return if @index.map {|_,v| v}.flatten.map {|toggle| toggle['identifier']}.include? identifier.to_s
-    raise "Cannot find '#{identifier}' FeatureFlag Identifier. Ensure its in the index YML"
+
+    raise RuntimeError.new("Cannot find '#{identifier}' FeatureFlag Identifier. Ensure its in the index YML")
   end
 end

--- a/app/src/fflag/cache_manager.rb
+++ b/app/src/fflag/cache_manager.rb
@@ -1,0 +1,29 @@
+module Fflag
+  class CacheManager
+    CACHE_KEY_PREFIX = 'fflag-cache'.freeze
+    private_constant :CACHE_KEY_PREFIX
+
+    DEFAULT_EXPIRES_IN = 15.minutes
+    private_constant :DEFAULT_EXPIRES_IN
+
+    def self.clear(identifier)
+      return unless Fflag.configuration.cache_enable
+
+      Rails.cache.delete(cache_key(identifier))
+    end
+
+    def self.fetch(identifier, expires_in, &blk)
+      return blk.call unless Fflag.configuration.cache_enable
+
+      Rails.cache.fetch(
+        cache_key(identifier),
+        expires_in: expires_in || DEFAULT_EXPIRES_IN,
+        &blk
+      )
+    end
+
+    def self.cache_key(identifier)
+      [CACHE_KEY_PREFIX, identifier].join('-')
+    end
+  end
+end

--- a/lib/fflag/engine.rb
+++ b/lib/fflag/engine.rb
@@ -1,4 +1,20 @@
 module Fflag
   class Engine < ::Rails::Engine
   end
+
+  class Configuration
+    attr_accessor :cache_enable
+
+    def initialize
+      @cache_enable = false
+    end
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
 end

--- a/lib/fflag/version.rb
+++ b/lib/fflag/version.rb
@@ -1,3 +1,3 @@
 module Fflag
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
* Toggle states are cached for 15 minutes if configured. Can use a different value: `FeatureFlag.is_on?(:my_flag, expires_in: 30.minutes)`

```ruby
# config/initializers/fflag.rb
Fflag.configure do |config|
  config.cache_enable = true # default: false
end
```

* Clear cache on switching state